### PR TITLE
Freecell - Convert Double to Int to get past compile error.

### DIFF
--- a/webkit-sodium/src/Engine.hs
+++ b/webkit-sodium/src/Engine.hs
@@ -94,7 +94,7 @@ elementPageXY doc elt = do
                 ox <- elementGetOffsetLeft elt
                 oy <- elementGetOffsetTop elt
                 Just parent <- elementGetOffsetParent elt
-                traverse body parent (x + ox, y + oy)
+                traverse body parent (x + truncate ox, y + truncate oy)
 
 -- The game logic expects alternating down-up-down-up, but the browser can produce
 -- bad sequences like down-up-down-down-up. So we sanitize the input.


### PR DESCRIPTION
Part of error was:
`src/Engine.hs:87:5:`
    Couldn't match type ‘Double’ with ‘Int’
    Expected type: IO (Int, Int)
    Actual type: IO (Double, Double)

`elementGetOffsetLeft` "returns" a Double. Note that
docs [1] say it's units are pixels, so Int should suffice.

Note: once compiled, game is broken: card dragging works for about 1 second, then game freezes.