### PR TITLE
Build ghcjs-hello with stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cabal-dev
 *.chs.h
 /.shelly/
 /gtk2hs/
+.stack-work

--- a/ghcjs-hello/ghcjs-hello.cabal
+++ b/ghcjs-hello/ghcjs-hello.cabal
@@ -9,12 +9,23 @@ flag jmacro
     Default: False
 
 executable ghcjs-hello
-    build-depends: deepseq >=1.3.0.2 && <1.4, lens -any,
-                   containers -any, random -any,
-                   template-haskell -any, base -any, blaze-html -any, filepath -any,
-                   hamlet -any, text -any, blaze-markup -any, shakespeare -any,
-                   ghcjs-dom >=0.1.1.0 && <0.2, mtl -any, sodium -any, webkit-sodium -any,
-                   jsaddle >=0.2.0.0 && <0.3
+    build-depends: base -any
+                 , blaze-html -any
+                 , blaze-markup -any
+                 , containers -any
+                 , deepseq >=1.3.0.2 && <1.5
+                 , filepath -any
+                 , ghcjs-dom >=0.1.1.0 && <0.3
+                 , hamlet -any
+                 , jsaddle >=0.3.0.0 && <0.4
+                 , lens -any
+                 , mtl -any
+                 , random -any
+                 , shakespeare -any
+                 , sodium -any
+                 , template-haskell -any
+                 , text -any
+                 , webkit-sodium -any
 
     if flag(jmacro)
         build-depends: jmacro >=0.6.3 && <0.8

--- a/mloc-js/mloc-js.cabal
+++ b/mloc-js/mloc-js.cabal
@@ -7,13 +7,26 @@ license-file: ""
 data-dir: "data"
 
 library
-    build-depends: base -any, blaze-html -any, blaze-markup -any,
-                   containers >=0.5.0.0 && <0.6, filepath -any, ghcjs-dom -any,
-                   hamlet -any, hscolour >=1.20.3 && <1.21,
-                   jsc >=0.1.0.0 && <0.2, lens >=3.8.5 && <3.11, mtl -any,
-                   random >=1.0.1.1 && <1.1, sodium -any, template-haskell -any,
-                   text -any, webkit-sodium -any, gloss -any, array -any,
-                   jmacro -any
+    build-depends: array -any
+                 , base -any
+                 , blaze-html -any
+                 , blaze-markup -any
+                 , containers
+                 , filepath -any
+                 , ghcjs-dom -any
+                 , gloss -any
+                 , hamlet -any
+                 , hscolour
+                 , jmacro -any
+                 , jsaddle
+                 , lens
+                 , mtl -any
+                 , random
+                 , shakespeare
+                 , sodium -any
+                 , template-haskell -any
+                 , text -any
+                 , webkit-sodium -any
     exposed-modules: Demo.DOM Demo.JavaScriptFFI Demo.LazyLoading
                      Demo.Threading
     exposed: True
@@ -22,13 +35,26 @@ library
     other-modules: Demo.Life WebKitUtils
 
 executable mloc-js
-    build-depends: base -any, blaze-html -any, blaze-markup -any,
-                   containers >=0.5.0.0 && <0.6, filepath -any, ghcjs-dom -any,
-                   hamlet -any, hscolour >=1.20.3 && <1.21,
-                   jsc >=0.1.0.0 && <0.2, lens >=3.8.5 && <3.11, mtl -any,
-                   random >=1.0.1.1 && <1.1, sodium -any, template-haskell -any,
-                   text -any, webkit-sodium -any, gloss -any, array -any,
-                   jmacro -any
+    build-depends: array -any
+                 , base -any
+                 , blaze-html -any
+                 , blaze-markup -any
+                 , containers
+                 , filepath -any
+                 , ghcjs-dom -any
+                 , gloss -any
+                 , hamlet -any
+                 , hscolour
+                 , jmacro -any
+                 , jsaddle
+                 , lens
+                 , mtl -any
+                 , random
+                 , shakespeare
+                 , sodium -any
+                 , template-haskell -any
+                 , text -any
+                 , webkit-sodium -any
     main-is: Main.hs
     buildable: True
     hs-source-dirs: src

--- a/mloc-js/src/Demo/DOM.hs
+++ b/mloc-js/src/Demo/DOM.hs
@@ -26,17 +26,16 @@ module Demo.DOM (
     helloDOM
 ) where
 
-import GHCJS.DOM.Document (documentGetElementById)
-import GHCJS.DOM.HTMLElement
-       (htmlElementSetInnerText)
+import GHCJS.DOM.Document (getElementById)
+import GHCJS.DOM.HTMLElement (setInnerText)
 import GHCJS.DOM.Types (castToHTMLElement)
 
 helloDOM doc = do
-    maybeExample <- documentGetElementById doc "example"
+    maybeExample <- getElementById doc "example"
     case maybeExample of
-        Just example -> htmlElementSetInnerText
+        Just example -> setInnerText
                                 (castToHTMLElement example)
-                                "Hello World"
+                                (Just "Hello World")
         Nothing      -> putStrLn "Element 'example' not found"
 
 

--- a/mloc-js/src/Demo/LazyLoading.hs
+++ b/mloc-js/src/Demo/LazyLoading.hs
@@ -27,8 +27,7 @@ module Demo.LazyLoading (
     lazyLoad_freecell
 ) where
 
-import GHCJS.DOM.HTMLElement
-       (htmlElementSetInnerHTML)
+import GHCJS.DOM.Element (setInnerHTML)
 import Engine (engine)
 import Freecell (mkFreecell)
 import Control.Concurrent (threadDelay, forkIO)
@@ -41,7 +40,7 @@ import Control.Monad (forever)
 --   a loader function that fetches the bundles.
 {-# NOINLINE lazyLoad_freecell #-}
 lazyLoad_freecell webView doc example = do
-    htmlElementSetInnerHTML example $
+    setInnerHTML example $ Just $
       "<div style=\""++style++"\" "++
       "id=\"freecell\" draggable=\"false\"></div>"
     unlisten <- engine webView "freecell" =<< mkFreecell

--- a/mloc-js/src/Demo/Threading.hs
+++ b/mloc-js/src/Demo/Threading.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE TemplateHaskell, QuasiQuotes, ScopedTypeVariables, Rank2Types #-}
+{-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
 -----------------------------------------------------------------------------
 --
 -- Module      :  Demo.Threading
@@ -15,25 +18,26 @@ module Demo.Threading (
   , isPrime
 ) where
 
-import WebKitUtils
-       (getDivElementById, getInputElementById, getImageElementById)
-import Control.Monad.Trans ( liftIO )
-import GHCJS.DOM (postGUISync)
-import GHCJS.DOM.Types
-       (Document(..), HTMLDivElement(..))
-import Control.Concurrent
-       (putMVar, tryTakeMVar, takeMVar, newEmptyMVar, threadDelay, forkIO)
-import Control.Monad (forever, forM_)
-import GHCJS.DOM.HTMLElement
-       (htmlElementSetInnerHTML, htmlElementSetInnerText)
-import Data.Text.Lazy (Text, unpack)
-import Text.Blaze.Html.Renderer.Text (renderHtml)
-import Text.Hamlet (Html, shamlet)
-import GHCJS.DOM.HTMLInputElement
-       (htmlInputElementGetValue)
-import GHCJS.DOM.Element
-       (elementSetAttribute, elementOnkeyup, elementOnkeypress,
-        elementOnkeydown)
+import           Control.Concurrent            (forkIO, newEmptyMVar, putMVar,
+                                                takeMVar, threadDelay,
+                                                tryTakeMVar)
+import           Control.Monad                 (forM_, forever)
+import           Control.Monad.Trans           (liftIO)
+import           Data.Maybe
+import           Data.Text.Lazy                (Text, unpack)
+import           GHCJS.DOM                     (postGUISync)
+import           GHCJS.DOM.Element             (keyDown, keyPress, keyUp,
+                                                setAttribute, setInnerHTML)
+import           GHCJS.DOM.EventM              (on)
+import           GHCJS.DOM.HTMLElement         (setInnerText)
+import           GHCJS.DOM.HTMLInputElement    (getValue)
+import           GHCJS.DOM.Types               (Document (..),
+                                                HTMLDivElement (..))
+import           Text.Blaze.Html.Renderer.Text (renderHtml)
+import           Text.Hamlet                   (Html, shamlet)
+import           WebKitUtils                   (getDivElementById,
+                                                getImageElementById,
+                                                getInputElementById)
 
 -- | Count to 10 slowly
 counting :: IO ()
@@ -48,7 +52,7 @@ counting = do
 
 primes :: Document -> HTMLDivElement -> IO ()
 primes doc example = do
-    htmlElementSetInnerHTML example . unpack $ renderHtml
+    setInnerHTML example . Just . unpack $ renderHtml
         [shamlet|$newline always
             <p>
                 Know any good prime numbers?
@@ -62,18 +66,18 @@ primes doc example = do
     next <- newEmptyMVar
     forkIO . forever $ do
       n <- takeMVar next
-      postGUISync . htmlElementSetInnerHTML prime . unpack $ validatePrime n
+      postGUISync . setInnerHTML prime . Just . unpack $ validatePrime n
 
     -- Something to set the next work item
     let setNext = do
-                    n <- htmlInputElementGetValue numInput
+                    n <- getValue numInput
                     tryTakeMVar next -- Discard existing next item
-                    putMVar next n
+                    putMVar next (fromMaybe "" n)
 
     -- Lets wire up some events
-    elementOnkeydown  numInput (liftIO setNext)
-    elementOnkeyup  numInput (liftIO setNext)
-    elementOnkeypress numInput (liftIO setNext)
+    on numInput keyDown (liftIO setNext)
+    on numInput keyUp (liftIO setNext)
+    on numInput keyPress (liftIO setNext)
     return ()
 
 isPrime :: Integer -> Bool

--- a/mloc-js/src/WebKitUtils.hs
+++ b/mloc-js/src/WebKitUtils.hs
@@ -17,56 +17,58 @@ module WebKitUtils (
   , createCanvasElement
 ) where
 
+import GHCJS.DOM
 import GHCJS.DOM.Types
-       (HTMLImageElement(..), castToHTMLImageElement, GType, isA,
-        gTypeHTMLImageElement, castToHTMLElement, gTypeHTMLElement,
-        HTMLElement(..), HTMLCanvasElement(..), castToHTMLCanvasElement,
-        gTypeHTMLCanvasElement, HTMLInputElement(..), HTMLDivElement(..),
-        Element(..), DocumentClass, castToHTMLInputElement,
-        gTypeHTMLInputElement, castToHTMLDivElement, gTypeHTMLDivElement)
-import GHCJS.DOM.Document
-       (documentCreateElement, documentGetElementById)
+       -- (HTMLImageElement(..), castToHTMLImageElement, GType, isA,
+       --  gTypeHTMLImageElement, castToHTMLElement, gTypeHTMLElement,
+       --  HTMLElement(..), HTMLCanvasElement(..), castToHTMLCanvasElement,
+       --  gTypeHTMLCanvasElement, HTMLInputElement(..), HTMLDivElement(..),
+       --  Element(..), DocumentClass, castToHTMLInputElement,
+       --  gTypeHTMLInputElement, castToHTMLDivElement, gTypeHTMLDivElement)
+import GHCJS.DOM.Document hiding (getElementById, error, createElement)
+import qualified GHCJS.DOM.Document as GHCJSDoc
+       -- (documentCreateElement, documentGetElementById)
 
 
-getHTMLElementById :: DocumentClass doc => doc -> String -> IO HTMLElement
+getHTMLElementById :: IsDocument doc => doc -> String -> IO HTMLElement
 getHTMLElementById = getElementById gTypeHTMLElement castToHTMLElement
 
-getDivElementById :: DocumentClass doc => doc -> String -> IO HTMLDivElement
+getDivElementById :: IsDocument doc => doc -> String -> IO HTMLDivElement
 getDivElementById = getElementById gTypeHTMLDivElement castToHTMLDivElement
 
-getInputElementById :: DocumentClass doc => doc -> String -> IO HTMLInputElement
+getInputElementById :: IsDocument doc => doc -> String -> IO HTMLInputElement
 getInputElementById = getElementById gTypeHTMLInputElement castToHTMLInputElement
 
-getImageElementById :: DocumentClass doc => doc -> String -> IO HTMLImageElement
+getImageElementById :: IsDocument doc => doc -> String -> IO HTMLImageElement
 getImageElementById = getElementById gTypeHTMLImageElement castToHTMLImageElement
 
-getElementById :: DocumentClass doc
+getElementById :: IsDocument doc
                => GType          -- ^ GObject type we want
                -> (Element -> a) -- ^ Suitable cast operator
                -> doc            -- ^ Document
                -> String         -- ^ ID of the element
                -> IO a
 getElementById gtype cast doc elementId = do
-    maybeElement <- documentGetElementById doc elementId
+    maybeElement <- GHCJSDoc.getElementById doc elementId
     case maybeElement of
         Just e | e `isA` gtype -> return (cast e)
         Just _  -> error $ "Element '" ++ elementId ++ "' found, but wrong type"
         Nothing -> error $ "Element '" ++ elementId ++ "' not found"
 
-createDivElement :: DocumentClass doc => doc -> IO HTMLDivElement
+createDivElement :: IsDocument doc => doc -> IO HTMLDivElement
 createDivElement = createElement gTypeHTMLDivElement castToHTMLDivElement "div"
 
-createCanvasElement :: DocumentClass doc => doc -> IO HTMLCanvasElement
+createCanvasElement :: IsDocument doc => doc -> IO HTMLCanvasElement
 createCanvasElement = createElement gTypeHTMLCanvasElement castToHTMLCanvasElement "canvas"
 
-createElement :: DocumentClass doc
+createElement :: IsDocument doc
               => GType          -- ^ GObject type we want
               -> (Element -> a) -- ^ Suitable cast operator
               -> String         -- ^ element type
               -> doc            -- ^ Document
               -> IO a
 createElement gtype cast elementType doc = do
-    maybeElement <- documentCreateElement doc elementType
+    maybeElement <- GHCJSDoc.createElement doc (Just elementType)
     case maybeElement of
         Just e | e `isA` gtype -> return (cast e)
         Just _  -> error $ "Created an '" ++ elementType ++ "', but it was the wrong type"

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,14 +14,29 @@ resolver: lts-3.13
 packages:
 - ghcjs-hello
 - webkit-sodium
+- mloc-js
 - location:
     git: git@github.com:ghcjs/jsaddle.git
     commit: 0dcf7e11ad6c5354302b7c30da3ffb1c61040972
+- location:
+    git: git@github.com:k-bx/gloss.git
+    commit: 3e7fd2c51db26e0c798aca378d25818b7eadd91a
+  subdirs:
+    - gloss
+    - gloss-rendering
+  extra-dep: true
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
 - ghcjs-dom-0.2.3.0
 - jsaddle-0.3.0.0
+- GLUT-2.7.0.3
+- OpenGL-2.13.1.1
+- webkitgtk3-0.14.1.0
+- webkitgtk3-javascriptcore-0.13.1.0
+- GLURaw-1.5.0.2
+- ObjectName-1.1.0.0
+- OpenGLRaw-2.6.1.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,43 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+compiler: ghcjs-0.2.0.20151029_ghc-7.10.2
+compiler-check: match-exact
+setup-info:
+  ghcjs:
+      source:
+            ghcjs-0.2.0.20151029_ghc-7.10.2:
+                    url: "https://github.com/nrolland/ghcjs/releases/download/v0.2.0.20151029/ghcjs-0.2.0.20151029.tar.gz"
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.13
+
+# Local packages, usually specified by relative directory name
+packages:
+- ghcjs-hello
+- webkit-sodium
+- ../jsaddle
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+- ghcjs-dom-0.2.3.0
+- jsaddle-0.3.0.0
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,7 @@ resolver: lts-3.13
 packages:
 - ghcjs-hello
 - webkit-sodium
-- mloc-js
+# - mloc-js
 - location:
     git: git@github.com:ghcjs/jsaddle.git
     commit: 0dcf7e11ad6c5354302b7c30da3ffb1c61040972

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,9 @@ resolver: lts-3.13
 packages:
 - ghcjs-hello
 - webkit-sodium
-- ../jsaddle
+- location:
+    git: git@github.com:ghcjs/jsaddle.git
+    commit: 0dcf7e11ad6c5354302b7c30da3ffb1c61040972
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:

--- a/webkit-sodium/src/Engine.hs
+++ b/webkit-sodium/src/Engine.hs
@@ -1,37 +1,37 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP               #-}
+
 module Engine where
 
-import Prelude hiding ((!!))
-import GHCJS.DOM.Document
-       (documentCreateElement, documentGetElementById, documentGetBody,
-        documentGetDocumentElement)
-import GHCJS.DOM.HTMLElement
-       (htmlElementInsertAdjacentElement, htmlElementSetInnerHTML,
-        htmlElementInsertAdjacentHTML)
-import GHCJS.DOM (WebView, webViewGetDomDocument)
-import GHCJS.DOM.Types
-       (castToHTMLElement, castToElement, Document,
-        HTMLElement, IsElement, IsMouseEvent, gTypeElement)
-import Control.Applicative ((<$>))
-import Control.Arrow
-import Control.Monad.Trans ( liftIO )
-import GHCJS.DOM.Element
-import GHCJS.DOM.EventM
-import GHCJS.DOM.MouseEvent hiding (MouseEvent)
-import GHCJS.DOM.Node
-import Control.Monad
-import Control.Monad.State.Strict
-import Data.IORef
-import Data.Maybe
+import           Control.Applicative         ((<$>))
+import           Control.Arrow
+import           Control.Monad
+import           Control.Monad.State.Strict
+import           Control.Monad.Trans         (liftIO)
+import           Data.IORef
+import           Data.Maybe
+import           GHCJS.DOM                   (WebView, webViewGetDomDocument)
+import           GHCJS.DOM.Document          (createElement, getBody,
+                                              getDocumentElement,
+                                              getElementById)
+import           GHCJS.DOM.Element
+import           GHCJS.DOM.EventM
+import           GHCJS.DOM.HTMLElement       (insertAdjacentElement,
+                                              insertAdjacentHTML)
+import           GHCJS.DOM.MouseEvent        hiding (MouseEvent)
+import           GHCJS.DOM.Node
+import           GHCJS.DOM.Types             (Document, HTMLElement, IsElement,
+                                              IsMouseEvent, castToElement,
+                                              castToHTMLElement, gTypeElement)
+import           Prelude                     hiding ((!!))
 
-import FRP.Sodium
-import Game
-import Control.Monad.Reader (ReaderT(..))
+import           Control.Monad.Reader        (ReaderT (..))
+import           FRP.Sodium
+import           Game
 #ifdef MIN_VERSION_jsaddle
-import Language.Javascript.JSaddle
-        (js2, js1, js0, js, jsg, (!!), (#), (<#), fun,
-         deRefVal, JSValue(..), runJSaddle)
-import Control.Lens ((^.))
+import           Control.Lens                ((^.))
+import           Language.Javascript.JSaddle (JSValue (..), deRefVal, fun, js,
+                                              js0, js1, js2, jsg, runJSaddle,
+                                              (!!), ( # ), (<#))
 #endif
 
 -- Convert (game) world to/from screen co-ordinates.
@@ -60,40 +60,40 @@ fromWorldRect ((xOrig,yOrig),(wid,hei)) = (
 
 -- | Get the mouse position relative to the top-left corner of the specified
 -- HTML element.
-getXYRelativeTo :: (IsElement elt, IsMouseEvent e, IsElement t) =>
-                   Document -> elt -> EventM e t (Int, Int)
+getXYRelativeTo :: (IsElement elt, IsMouseEvent e) =>
+                   Document -> elt -> EventM t e (Int, Int)
 getXYRelativeTo doc container = do
     (px, py) <- mousePageXY doc container
     (cx, cy) <- liftIO $ elementPageXY doc container
     return (px - cx, py - cy)
 
-mousePageXY :: (IsElement elt, IsMouseEvent e, IsElement t) =>
-               Document -> elt -> EventM e t (Int, Int)
+mousePageXY :: (IsElement elt, IsMouseEvent e) =>
+               Document -> elt -> EventM t e (Int, Int)
 mousePageXY doc container = do
     (x, y) <- mouseClientXY
     liftIO $ do
-	Just body <- documentGetBody doc     -- doc.body
-        bodyScrollLeft <- elementGetScrollLeft body
-        bodyScrollTop  <- elementGetScrollTop body
-        Just docElt <- documentGetDocumentElement doc
-        docEltScrollLeft <- elementGetScrollLeft docElt
-        docEltScrollTop <- elementGetScrollTop docElt
+        Just body <- getBody doc     -- doc.body
+        bodyScrollLeft <- getScrollLeft body
+        bodyScrollTop  <- getScrollTop body
+        Just docElt <- getDocumentElement doc
+        docEltScrollLeft <- getScrollLeft docElt
+        docEltScrollTop <- getScrollTop docElt
         return (x + bodyScrollLeft + docEltScrollLeft, y + bodyScrollTop + docEltScrollTop)
 
 -- | Get the top/left position of this element relative to the page.
 elementPageXY :: IsElement elt => Document -> elt -> IO (Int, Int)
 elementPageXY doc elt = do
-    Just body <- documentGetBody doc
+    Just body <- getBody doc
     traverse body (castToElement elt) (0,0)
   where
     traverse body elt (x, y) = do
-        eq <- nodeIsEqualNode elt (Just body)
+        eq <- isEqualNode elt (Just body)
         if eq
             then return (x, y)
             else do
-                ox <- elementGetOffsetLeft elt
-                oy <- elementGetOffsetTop elt
-                Just parent <- elementGetOffsetParent elt
+                ox <- getOffsetLeft elt
+                oy <- getOffsetTop elt
+                Just parent <- getOffsetParent elt
                 traverse body parent (x + round ox, y + round oy)
 
 -- The game logic expects alternating down-up-down-up, but the browser can produce
@@ -118,7 +118,7 @@ engine webView containerId game = do
     putStrLn "Haskell Freecell"
 
     Just doc <- webViewGetDomDocument webView
-    Just container <- fmap castToHTMLElement <$> documentGetElementById doc containerId
+    Just container <- fmap castToHTMLElement <$> getElementById doc containerId
     -- Construct a mouse event that lives in FRP land, and a push action
     -- that allows us to push values into it from IO land.
     (eMouse, pushMouse) <- sync newEvent
@@ -126,13 +126,13 @@ engine webView containerId game = do
     sanitize <- mkSanitize Up
 
     -- Listen to mouse events from WebKit
-    elementOnmousedown container $ do
+    on container mouseDown $ do
         xy <- getXYRelativeTo doc container
         liftIO . sanitize Down . sync . pushMouse . MouseDown . toWorld $ xy
-    elementOnmousemove container $ do
+    on container mouseMove $ do
         xy <- getXYRelativeTo doc container
         liftIO . sync . pushMouse . MouseMove . toWorld $ xy
-    elementOnmouseup container $ do
+    on container mouseUp $ do
         xy <- getXYRelativeTo doc container
         liftIO . sanitize Up . sync . pushMouse . MouseUp . toWorld $ xy
 
@@ -153,36 +153,43 @@ engine webView containerId game = do
         c ^. addEventListener "touchstart" (fun $ \f this [e] -> do
           e ^. preventDefault
           n <- e ^. touches . jsLength >>= deRefVal
-          when (n == ValNumber 1) $ do
-              t <- (e ^. touches) !! 0
-              vx <- t ^. pageX >>= deRefVal
-              vy <- t ^. pageY >>= deRefVal
-              case (vx, vy) of
-                (ValNumber x, ValNumber y) ->
-                  liftIO . sanitize Down . sync . pushMouse . MouseDown . toWorld $ ((floor x)-cx, (floor y)-cy)
-                _ -> return ())
+          case n of
+              ValNumber 1 -> do
+                t <- (e ^. touches) !! 0
+                vx <- t ^. pageX >>= deRefVal
+                vy <- t ^. pageY >>= deRefVal
+                case (vx, vy) of
+                  (ValNumber x, ValNumber y) ->
+                    liftIO . sanitize Down . sync . pushMouse . MouseDown . toWorld
+                      $ ((floor x)-cx, (floor y)-cy)
+                  _ -> return ()
+              _ -> return ())
         c ^. addEventListener "touchmove" (fun $ \f this [e] -> do
           e ^. preventDefault
           n <- e ^. touches . jsLength >>= deRefVal
-          when (n == ValNumber 1) $ do
-              t <- (e ^. touches) !! 0
-              vx <- t ^. pageX >>= deRefVal
-              vy <- t ^. pageY >>= deRefVal
-              case (vx, vy) of
-                (ValNumber x, ValNumber y) ->
-                  liftIO . sync . pushMouse . MouseMove . toWorld $ ((floor x)-cx, (floor y)-cy)
-                _ -> return ())
+          case n of
+              ValNumber 1 -> do
+                t <- (e ^. touches) !! 0
+                vx <- t ^. pageX >>= deRefVal
+                vy <- t ^. pageY >>= deRefVal
+                case (vx, vy) of
+                  (ValNumber x, ValNumber y) ->
+                    liftIO . sync . pushMouse . MouseMove . toWorld $ ((floor x)-cx, (floor y)-cy)
+                  _ -> return ()
+              _ -> return ())
         c ^. addEventListener "touchend" (fun $ \f this [e] -> do
           e ^. preventDefault
           n <- e ^. changedTouches . jsLength >>= deRefVal
-          when (n == ValNumber 1) $ do
-              t <- (e ^. changedTouches) !! 0
-              vx <- t ^. pageX >>= deRefVal
-              vy <- t ^. pageY >>= deRefVal
-              case (vx, vy) of
-                (ValNumber x, ValNumber y) ->
-                  liftIO . sanitize Up . sync . pushMouse . MouseUp . toWorld $ ((floor x)-cx, (floor y)-cy)
-                _ -> return ())
+          case n of
+              ValNumber 1 -> do
+                t <- (e ^. changedTouches) !! 0
+                vx <- t ^. pageX >>= deRefVal
+                vy <- t ^. pageY >>= deRefVal
+                case (vx, vy) of
+                  (ValNumber x, ValNumber y) ->
+                    liftIO . sanitize Up . sync . pushMouse . MouseUp . toWorld $ ((floor x)-cx, (floor y)-cy)
+                  _ -> return ()
+              _ -> return ())
 #endif
 
     -- Instantiate the FRP logic: We give it our mouse event, and it gives us back the
@@ -218,15 +225,15 @@ showAll doc container sprites =
             -- Remember the behaviour's last value
             lastRef <- newIORef []
             -- Listen to changes in the value of the behaviour (a list of sprites)
-            unlisten <- sync $ listen (values beh) $ \these -> do
+            unlisten <- sync $ listen (value beh) $ \these -> do
                 last <- readIORef lastRef
-                let toAdd = drop (length last) these
-                    toRemove = drop (length these) (map fst last)
+                let toAdd = Prelude.drop (length last) these
+                    toRemove = Prelude.drop (length these) (map fst last)
                     toModify = zip these last
                     keptImgs = map (\(_, (elt, _)) -> elt) toModify
                     noOfKeptImgs = length keptImgs
                 -- If there are fewer elements than last time, we delete the excess ones.
-                mapM_ (nodeRemoveChild container . Just) toRemove
+                mapM_ (removeChild container . Just) toRemove
                 -- If the first n sprites exist in both the old and new list, we
                 -- re-use them, and just modify their position and appearance as necessary
                 sequence_ $ zipWith (\zIx (newSprite, (elt, oldSprite)) -> do
@@ -237,11 +244,11 @@ showAll doc container sprites =
                     ) [zIxRoot..] toModify
                 -- If there are more elements than last time, we create the new ones
                 addedImgs <- sequence $ zipWith (\zIx sprite@(rect, fn) -> do
-                        Just elt <- fmap castToHTMLElement <$> documentCreateElement doc "img"
+                        Just elt <- fmap castToHTMLElement <$> createElement doc (Just "img")
                         position elt rect zIx
                         associate elt fn
-                        elementSetAttribute elt "ondragstart" "return false"
-                        nodeAppendChild container (Just elt)
+                        setAttribute elt "ondragstart" "return false"
+                        appendChild container (Just elt)
                         return elt
                     ) [zIxRoot + noOfKeptImgs..] toAdd
                 writeIORef lastRef (zip (keptImgs ++ addedImgs) these)
@@ -249,9 +256,9 @@ showAll doc container sprites =
     -- Set the necessary attributes to position the image according to the specified
     -- rectangle
     position elt rect zIx = do
-        elementSetAttribute elt "style" (style origin zIx)
-        elementSetAttribute elt "width" (show wid)
-        elementSetAttribute elt "height" (show hei)
+        setAttribute elt "style" (style origin zIx)
+        setAttribute elt "width" (show wid)
+        setAttribute elt "height" (show hei)
       where
         (origin, (wid, hei)) = fromWorldRect rect
         style (x, y) zIx = "position:absolute;top:"++show y
@@ -268,5 +275,5 @@ showAll doc container sprites =
             "user-select: none"
     -- Associate the image element with a URL, i.e. set its appearance.
     associate elt fn =
-        elementSetAttribute elt "src" ("http://ghcjs.github.com/"++fn)
+        setAttribute elt "src" ("http://ghcjs.github.com/"++fn)
 

--- a/webkit-sodium/src/Freecell.hs
+++ b/webkit-sodium/src/Freecell.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DoRec #-}
+{-# LANGUAGE RecursiveDo #-}
+
 -- | A minimal implementation of Freecell, a soltaire card game, to demonstrate
 -- the Sodium reactive programming system.
 --
@@ -128,8 +129,8 @@ stack eMouse initCards loc@(Stack ix) freeSpaces eDrop = do
         positions = iterate (\(x, y) -> (x, y-overlapY)) orig
     rec
         cards <- hold initCards (eRemoveCards `merge` eAddCards)
-        let eAddCards = snapshotWith (\newCards cards -> cards ++ newCards) eDrop cards
-            eMouseSelection = filterJust $ snapshotWith (\mev cards ->
+        let eAddCards = snapshot (\newCards cards -> cards ++ newCards) eDrop cards
+            eMouseSelection = filterJust $ snapshot (\mev cards ->
                     case mev of
                         MouseDown pt@(x, y) | x >= origX - cardWidth && x <= origX + cardWidth ->
                             let n = length cards
@@ -168,7 +169,7 @@ cell eMouse loc@(Cell ix) eDrop = do
         rect = (orig, cardSize)
     rec
         mCard <- hold Nothing $ eRemove `merge` (Just . head <$> eDrop)
-        let eMouseSelection = filterJust $ snapshotWith (\mev mCard ->
+        let eMouseSelection = filterJust $ snapshot (\mev mCard ->
                     case (mev, mCard) of
                         (MouseDown pt, Just card) | pt `inside` rect ->
                             Just (Nothing, Bunch (fst rect) pt [card] loc)
@@ -195,13 +196,13 @@ grave eMouse eDrop = do
         (cardWidth, cardHeight) = cardSize
         wholeRect = (((xOf 0 + xOf 3) * 0.5, topRow), ((cardSpacingNarrow * 3 + cardWidth*2) * 0.5, cardHeight))    
     rec
-        let eDropModify = snapshotWith (\newCards slots ->
+        let eDropModify = snapshot (\newCards slots ->
                     let newCard@(Card _ suit) = head newCards
                         ix = fromEnum suit
                     in  take ix slots ++ [Just newCard] ++ drop (ix+1) slots 
                 ) eDrop slots
         slots <- hold [Nothing, Nothing, Nothing, Nothing] (eDropModify `merge` eRemove)
-        let eMouseSelection = filterJust $ snapshotWith (\mev slots ->
+        let eMouseSelection = filterJust $ snapshot (\mev slots ->
                     case mev of
                         MouseDown pt ->
                             let isIn = map (pt `inside`) areas
@@ -252,7 +253,7 @@ dragger eMouse eStartDrag = do
             MouseDown pt -> pt
     rec
         dragging <- hold Nothing $ (const Nothing <$> eDrop) `merge` (Just <$> eStartDrag)
-        let eDrop = filterJust $ snapshotWith (\mev mDragging ->
+        let eDrop = filterJust $ snapshot (\mev mDragging ->
                     case (mev, mDragging) of
                         -- If the mouse is released, and we are dragging...
                         (MouseUp pt, Just dragging) -> Just (cardPos pt dragging, dragging)
@@ -272,7 +273,7 @@ dragger eMouse eStartDrag = do
 -- | Determine where dropped cards are routed to.
 dropper :: Event (Point, Bunch) -> Behavior [Destination] -> Event (Location, [Card])
 dropper eDrop dests =
-    snapshotWith (\(pt, bunch) dests ->
+    snapshot (\(pt, bunch) dests ->
                 -- If none of the destinations will accept the dropped cards, then send them
                 -- back where they originated from.
                 let findDest [] = (buOrigin bunch, buCards bunch)

--- a/webkit-sodium/src/Main.hs
+++ b/webkit-sodium/src/Main.hs
@@ -2,47 +2,46 @@ module Main (
     main
 ) where
 
-import Engine
-import Freecell
+import           Engine
+import           Freecell
 
-import GHCJS.DOM.Document
-       (documentCreateElement, documentGetElementById, documentGetBody)
-import GHCJS.DOM.HTMLElement
-       (htmlElementInsertAdjacentElement, htmlElementSetInnerHTML,
-        htmlElementInsertAdjacentHTML)
-import GHCJS.DOM.Types (castToHTMLDivElement)
-import GHCJS.DOM.CSSStyleDeclaration
-       (cssStyleDeclarationSetProperty)
-import Control.Applicative ((<$>))
-import Control.Arrow
-import Control.Monad.Trans ( liftIO )
-import GHCJS.DOM.Element
-import GHCJS.DOM.Node
-import Control.Monad
-import System.Random
-import FRP.Sodium
-import GHCJS.DOM (runWebGUI, webViewGetDomDocument)
-import Control.Concurrent (threadDelay, forkIO)
+import           Control.Applicative           ((<$>))
+import           Control.Arrow
+import           Control.Concurrent            (forkIO, threadDelay)
+import           Control.Monad
+import           Control.Monad.Trans           (liftIO)
+import           FRP.Sodium
+import           GHCJS.DOM                     (runWebGUI,
+                                                webViewGetDomDocument)
+import           GHCJS.DOM.CSSStyleDeclaration (setProperty)
+import           GHCJS.DOM.Document            (createElement, getBody,
+                                                getElementById)
+import           GHCJS.DOM.Element
+import           GHCJS.DOM.HTMLElement         (insertAdjacentElement,
+                                                insertAdjacentHTML)
+import           GHCJS.DOM.Node
+import           GHCJS.DOM.Types               (castToHTMLDivElement)
+import           System.Random
 
 -- Comments show how what these FFI calls should work when the
 -- code compiled is compiled with GHCJS
 main = do
   runWebGUI $ \ webView -> do
     Just doc <- webViewGetDomDocument webView -- webView.document
-    Just body <- documentGetBody doc     -- doc.body
+    Just body <- getBody doc     -- doc.body
 
     -- If we are in the browser let's shrink the terminal window to make room
-    mbTerminal    <- fmap castToHTMLDivElement   <$> documentGetElementById doc "terminal"
+    mbTerminal    <- fmap castToHTMLDivElement   <$> getElementById doc "terminal"
     case mbTerminal of
       Just terminal -> do
-        Just style <- elementGetStyle terminal
-        cssStyleDeclarationSetProperty style "height" "100" ""
+        Just style <- getStyle terminal
+        setProperty style "height" (Just "100") ""
       _             -> return ()
 
-    Just div <- fmap castToHTMLDivElement <$> documentCreateElement doc "div"
-    elementSetAttribute div "style" "position:relative;left:0px;top:0px;background-color:#e0d0ff;width:700px;height:500px"
-    elementSetAttribute div "id" "freecell"
-    nodeAppendChild body (Just div)
+    Just div <- fmap castToHTMLDivElement <$> createElement doc (Just "div")
+    setAttribute div "style" "position:relative;left:0px;top:0px;background-color:#e0d0ff;width:700px;height:500px"
+    setAttribute div "id" "freecell"
+    appendChild body (Just div)
     unlisten <- engine webView "freecell" =<< mkFreecell
 
     -- Prevent finalizers running too soon


### PR DESCRIPTION
ghcjs-examples looks a bit broken to me lately. What I did was shaping it up so that you can do:

```
stack setup
```

to set up working ghcjs binary, and do:

```
stack build
```

to build it locally. Right now only ghcjs-hello builds, also few things were fixed by rather a hack than a proper fix, will need to think on this later.

Please review!
